### PR TITLE
[BUGFIX] Improve form data provider ordering

### DIFF
--- a/Classes/Form/FormDataProvider/DotFormsDataProvider.php
+++ b/Classes/Form/FormDataProvider/DotFormsDataProvider.php
@@ -26,9 +26,6 @@ class DotFormsDataProvider implements FormDataProviderInterface
                         }
                         $currentArray = $currentArray[$fieldPart] ?? null;
                     }
-                    if ($fieldConfig['config']['type'] === 'select' && !is_array($currentArray)) {
-                        $currentArray = $currentArray === null ? $result['databaseRow'][$fieldName] ?? [] : [$currentArray];
-                    }
                     $result['databaseRow'][$fieldName] = $currentArray ?? $result['databaseRow'][$fieldName] ?? null;
                 }
             }

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -10,4 +10,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRe
     'depends' => [
         \TYPO3\CMS\Backend\Form\FormDataProvider\DatabaseEditRow::class
     ],
+    'before' => [
+        \TYPO3\CMS\Backend\Form\FormDataProvider\TcaRadioItems::class,
+        \TYPO3\CMS\Backend\Form\FormDataProvider\TcaCheckboxItems::class,
+        \TYPO3\CMS\Backend\Form\FormDataProvider\TcaGroup::class,
+        \TYPO3\CMS\Backend\Form\FormDataProvider\TcaSelectItems::class
+    ]
 ];


### PR DESCRIPTION
Run dot forms data provider before data providers for radio buttons, checkboxes, select and group fields to make sure, the data is ready to be processed by the field type specific form data providers.