### PR TITLE
[BUGFIX] Make category fields work

### DIFF
--- a/Classes/Database/Schema/TcaSchemaOverride.php
+++ b/Classes/Database/Schema/TcaSchemaOverride.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace WEBcoast\DotForms\Database\Schema;
+
+
+use Doctrine\DBAL\Schema\Table;
+use TYPO3\CMS\Core\Database\Schema\DefaultTcaSchema;
+
+class TcaSchemaOverride extends DefaultTcaSchema
+{
+    /**
+     * @param array|Table[] $tables
+     * @return array|Table[]
+     */
+    protected function enrichSingleTableFields($tables): array
+    {
+        /** @var Table[] $tables */
+        $tables = parent::enrichSingleTableFields($tables);
+        foreach ($tables as $table) {
+            foreach ($table->getColumns() as $column) {
+                if (str_contains($column->getName(), '.')) {
+                    $table->dropColumn($column->getName());
+                }
+            }
+        }
+
+        return $tables;
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -17,3 +17,7 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRe
         \TYPO3\CMS\Backend\Form\FormDataProvider\TcaSelectItems::class
     ]
 ];
+
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\TYPO3\CMS\Core\Database\Schema\DefaultTcaSchema::class] = [
+    'className' => \WEBcoast\DotForms\Database\Schema\TcaSchemaOverride::class,
+];


### PR DESCRIPTION
* override (XCLASS) `DefaultTcaSchema` to avoid extra SQL for fields with type `category` from fields with dot notation